### PR TITLE
♻️ Output coverage report in XML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ source = ["olympia"]
 show_missing = true
 fail_under = 100
 
+[tool.coverage.xml]
+output = "coverage.xml"
+
 [tool.mypy]
 strict = true
 pretty = true


### PR DESCRIPTION
This PR outputs the coverage report in XML in order to better sync with Codecov.